### PR TITLE
Version 1.0.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,8 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=1.0.0
-VERSION_CODE=1
+VERSION_NAME=1.0.1
+VERSION_CODE=2
 GROUP=ru.tinkoff.decoro
 
 POM_DESCRIPTION=Android library for text formatting

--- a/library/src/main/java/ru/tinkoff/decoro/MaskImpl.java
+++ b/library/src/main/java/ru/tinkoff/decoro/MaskImpl.java
@@ -108,6 +108,7 @@ public class MaskImpl implements Mask {
         return toString(false);
     }
 
+    @NonNull
     private String toString(boolean allowDecoration) {
         return firstSlot != null ? toStringFrom(firstSlot, allowDecoration) : "";
     }

--- a/library/src/main/java/ru/tinkoff/decoro/parser/PhoneNumberUnderscoreSlotsParser.java
+++ b/library/src/main/java/ru/tinkoff/decoro/parser/PhoneNumberUnderscoreSlotsParser.java
@@ -33,7 +33,7 @@ public class PhoneNumberUnderscoreSlotsParser extends UnderscoreDigitSlotsParser
     @NonNull
     @Override
     public Slot[] parseSlots(@NonNull CharSequence rawMask) {
-        rule = Slot.RULE_INPUT_MOVES_INPUT;
+        rule = Slot.RULE_INPUT_MOVES_INPUT | Slot.RULE_INPUT_REPLACE;
         return super.parseSlots(rawMask);
     }
 
@@ -44,7 +44,7 @@ public class PhoneNumberUnderscoreSlotsParser extends UnderscoreDigitSlotsParser
         }
 
         final Slot slot = new Slot(rule, character, SlotValidatorSet.setOf(new SlotValidators.DigitValidator()));
-        rule |= Slot.RULE_FORBID_LEFT_OVERWRITE;
+        rule = Slot.RULE_INPUT_MOVES_INPUT;
 
         return slot;
     }

--- a/library/src/main/java/ru/tinkoff/decoro/watchers/FormatWatcher.java
+++ b/library/src/main/java/ru/tinkoff/decoro/watchers/FormatWatcher.java
@@ -50,8 +50,6 @@ public abstract class FormatWatcher implements TextWatcher, MaskFactory {
 
     private CharSequence textBeforeChange;
 
-    private boolean forceHidingHead;
-
     private Mask mask;
     private TextView textView;
     private boolean initWithMask;
@@ -171,11 +169,6 @@ public abstract class FormatWatcher implements TextWatcher, MaskFactory {
         textBeforeChange = new String(s.toString());
 
         diffMeasures.calculateBeforeTextChanged(start, count, after);
-
-        forceHidingHead = !mask.isHideHardcodedHead() && after == 0 && start == 0;
-        if (forceHidingHead) {
-            mask.setHideHardcodedHead(true);
-        }
     }
 
     @Override
@@ -253,11 +246,6 @@ public abstract class FormatWatcher implements TextWatcher, MaskFactory {
         }
 
         textBeforeChange = null;
-
-        if (forceHidingHead) {
-            mask.setHideHardcodedHead(false);
-            forceHidingHead = false;
-        }
     }
 
     public Mask getMask() {

--- a/library/src/test/java/ru/tinkoff/decoro/MaskTest.java
+++ b/library/src/test/java/ru/tinkoff/decoro/MaskTest.java
@@ -18,17 +18,25 @@ package ru.tinkoff.decoro;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
+import ru.tinkoff.decoro.parser.PhoneNumberUnderscoreSlotsParser;
 import ru.tinkoff.decoro.slots.PredefinedSlots;
 import ru.tinkoff.decoro.slots.Slot;
+import ru.tinkoff.decoro.slots.SlotValidatorSet;
+import ru.tinkoff.decoro.slots.SlotValidators;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
 /**
- * @author Mikhail Artemev
+ * @author Mikhail Artemyev
  */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class MaskTest {
 
     Mask mask;
@@ -138,6 +146,61 @@ public class MaskTest {
         mask.insertFront("123");
         assertEquals("+123", mask.toUnformattedString());
 
+    }
+
+    @Test
+    public void replace(){
+        Mask mask = new MaskImpl(
+                new Slot[]{
+                        new Slot(Slot.RULE_INPUT_REPLACE, '1', SlotValidatorSet.setOf(new SlotValidators.GenerousValidator())),
+                        new Slot(Slot.RULE_INPUT_REPLACE, '2', SlotValidatorSet.setOf(new SlotValidators.GenerousValidator())),
+                        new Slot(Slot.RULE_INPUT_REPLACE, '3', SlotValidatorSet.setOf(new SlotValidators.GenerousValidator())),
+                        new Slot(Slot.RULE_INPUT_REPLACE, null, SlotValidatorSet.setOf(new SlotValidators.GenerousValidator()))
+                }, true
+        );
+
+        assertEquals("123", mask.toString());
+
+        assertEquals(1,mask.insertFront("0"));
+        assertEquals(2,mask.insertAt(1, "1"));
+
+        assertEquals("013", mask.toString());
+    }
+
+    @Test
+    public void cursorPosition() {
+        assertEquals(0, mask.insertFront("")); // (empty)
+        assertEquals(2, mask.insertFront("1")); // 1-|
+        assertEquals(1, mask.removeBackwards(1, 1)); // 1|-
+        assertEquals(0, mask.removeBackwards(0, 1)); // (empty)
+
+        assertEquals(4, mask.insertFront("12345656")); // 1-23|
+    }
+
+    @Test
+    public void phoneCursorPosition() {
+        Mask phoneMask = new MaskImpl(new PhoneNumberUnderscoreSlotsParser().parseSlots("+359 ___ __ __"), true);
+        phoneMask.setHideHardcodedHead(false);
+
+        assertEquals(5, phoneMask.insertFront("3")); // +359 |
+        assertEquals(4, phoneMask.removeBackwards(4, 1)); // +359|
+        assertEquals(6, phoneMask.insertAt(3, "3")); // +359 3|
+
+        assertEquals(0, phoneMask.removeBackwards(6, 8)); // |+359
+        assertEquals(5, phoneMask.insertAt(0, "3")); // +359 |
+
+        assertEquals(6, phoneMask.insertAt(1, "9")); // +359 9|
+        assertEquals(6, phoneMask.insertAt(1, "5")); // +359 5|9
+        assertEquals(5, phoneMask.insertAt(1, "3")); // +359 |59
+        assertEquals(6, phoneMask.insertAt(2, "3")); // +359 3|59
+
+        assertEquals(6, phoneMask.insertFront("5")); // +359 5|35 9
+        assertEquals(10, phoneMask.insertAt(8, "4")); // +359 535 4|9
+
+        assertEquals("+359 535 49", phoneMask.toString());
+
+        assertEquals(1, phoneMask.removeBackwards(11, 11)); // +|359
+        assertEquals("+359 ", phoneMask.toString());
     }
 
 }

--- a/library/src/test/java/ru/tinkoff/decoro/SlotTest.java
+++ b/library/src/test/java/ru/tinkoff/decoro/SlotTest.java
@@ -1,19 +1,3 @@
-/*
- * Copyright © 2016 Tinkoff Bank
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package ru.tinkoff.decoro;
 
 import android.os.Parcel;
@@ -34,7 +18,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
 /**
- * @author Mikhail Artemev
+ * @author Mikhail Artemyev
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
@@ -42,7 +26,7 @@ public class SlotTest {
 
     @Test
     public void parcelable() {
-        Slot before = new Slot(Slot.RULE_INPUT_MOVES_CURRENT,
+        Slot before = new Slot(Slot.RULES_DEFAULT,
                 'x',
                 SlotValidatorSet.setOf(new SlotValidators.MaskedDigitValidator()));
 
@@ -68,12 +52,12 @@ public class SlotTest {
     }
 
     @Test
-    public void setValueOffset() {
-        Slot b = new Slot(Slot.RULE_INPUT_MOVES_CURRENT, null, null);
+    public void setValueOffset(){
+        Slot b = new Slot(Slot.RULES_DEFAULT, null, null);
         assertEquals(1, b.setValue(' '));
         assertEquals(1, b.setValue('2'));
 
-        Slot c = new Slot(Slot.RULE_INPUT_MOVES_CURRENT, null, null);
+        Slot c = new Slot(Slot.RULES_DEFAULT, null, null);
         c.setPrevSlot(b);
         b.setNextSlot(c);
 

--- a/library/src/test/java/ru/tinkoff/decoro/SlotTest.java
+++ b/library/src/test/java/ru/tinkoff/decoro/SlotTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2016 Tinkoff Bank
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package ru.tinkoff.decoro;
 
 import android.os.Parcel;
@@ -18,7 +34,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
 /**
- * @author Mikhail Artemyev
+ * @author Mikhail Artemev
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)


### PR DESCRIPTION
Version release 1.0.1

What's new:
1) New Slot insert rule - Slot.RULE_INPUT_REPLACE. New character of such slot will replace current slot's value without modifying neighbour slots.
2) Slot rule that forbid input from left is removed. This is now default behavior for Slot.RULE_INPUT_MOVES_INPUT. In combination with Slot.RULE_INPUT_REPLACE hardcoded slot's value can be replaced with its current value (previously this was a default behavior for hardcoded slots).
3) Fixed bug of incorrect calculating of cursor position when inserting to hardcoded head.