### PR TITLE
1.2.0 Rlease

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Gradle file that is not added to Git allows you
+# to configure local builds
+gradle/local.gradle
+
 # [Android] ========================
 # Built application files
 *.apk

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ watcher.installOn(editText); // install on any TextView
 PredefinedSlots.SINGLE_SLOT                   // Any character
 PredefinedSlots.RUS_PHONE_NUMBER              // Russian phone number formatted as +7 (___) ___-__-__ (digits only)
 PredefinedSlots.RUS_PASSPORT                  // Series and number of russian passport formatted as ____ ______  (digits only)
-PredefinedSlots.CARD_NUMBER_USUAL             // Credit card number formatted as ____ ____ ____ ____ (digits only)
-PredefinedSlots.MASKABLE_CARD_NUMBER_USUAL    // Credit card number formatted as ____ ____ ____ ____ (digits and chars 'X', 'x', '*')
+PredefinedSlots.CARD_NUMBER_STANDARD          // Credit card number formatted as ____ ____ ____ ____ (digits only)
+PredefinedSlots.CARD_NUMBER_STANDARD_MASKABLE // Credit card number formatted as ____ ____ ____ ____ (digits and chars 'X', 'x', '*')
 PredefinedSlots.CARD_NUMBER_MAESTRO           // Credit card number formatted as ________ ____ (digits only)
-PredefinedSlots.MASKABLE_CARD_NUMBER_MAESTRO  // Credit card number formatted as ________ ____ (digits and chars 'X', 'x', '*')
+PredefinedSlots.CARD_NUMBER_MAESTRO_MASKABLE  // Credit card number formatted as ________ ____ (digits and chars 'X', 'x', '*')
 ```
 
 ##### Example 5. Using custom mask

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Android library designed for automatic formatting of text input by custom rules.
 Add to the `build.gradle` of your app module:
 ```Groovy
 dependencies {
-    compile "ru.tinkoff.decoro:decoro:1.1.1"
+    compile "ru.tinkoff.decoro:decoro:1.2.0"
 }
 ```
 
@@ -86,6 +86,6 @@ More examples and details can be found [in our wiki][details wiki] (in Russian y
 
 [maven]: http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22ru.tinkoff.decoro%22%20
 [details wiki]: https://github.com/TinkoffCreditSystems/decoro/wiki
-[img version shield]: https://img.shields.io/badge/version-1.1.1-blue.svg
+[img version shield]: https://img.shields.io/badge/version-1.2.0-blue.svg
 [img sample static]: https://raw.githubusercontent.com/TinkoffCreditSystems/decoro/master/img/static1.gif
 [img sample dynamic]: https://raw.githubusercontent.com/TinkoffCreditSystems/decoro/master/img/dynamic1.gif

--- a/demo/src/main/java/ru/tinkoff/decoro/demo/MaskSelectorDialog.java
+++ b/demo/src/main/java/ru/tinkoff/decoro/demo/MaskSelectorDialog.java
@@ -59,7 +59,7 @@ public class MaskSelectorDialog extends DialogFragment implements DialogInterfac
                 maskDescriptor = MaskDescriptor.ofSlots(PredefinedSlots.RUS_PHONE_NUMBER);
                 break;
             case MASK_CARD_STANDARD:
-                maskDescriptor = MaskDescriptor.ofSlots(PredefinedSlots.CARD_NUMBER_STANDART_MASKABLE);
+                maskDescriptor = MaskDescriptor.ofSlots(PredefinedSlots.CARD_NUMBER_STANDARD_MASKABLE);
                 break;
             case MASK_CARD_MAESTRO:
                 maskDescriptor = MaskDescriptor.ofSlots(PredefinedSlots.CARD_NUMBER_MAESTRO_MASKABLE)

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,8 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=1.1.1
-VERSION_CODE=7
+VERSION_NAME=1.2.0
+VERSION_CODE=8
 GROUP=ru.tinkoff.decoro
 
 POM_DESCRIPTION=Android library for text formatting

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,6 +1,11 @@
 apply plugin: 'com.android.library'
 apply from: '../gradle/publish-lib.gradle'
 
+def customGradleScript = '../gradle/local.gradle'
+if(new File(customGradleScript).exists()){
+    apply from: customGradleScript
+}
+
 android {
     compileSdkVersion rootProject.targetSdk
     buildToolsVersion rootProject.buildToolsVersion

--- a/library/src/main/java/ru/tinkoff/decoro/FormattedTextChangeListener.java
+++ b/library/src/main/java/ru/tinkoff/decoro/FormattedTextChangeListener.java
@@ -17,13 +17,13 @@
 package ru.tinkoff.decoro;
 
 
+import android.support.annotation.NonNull;
+
 import ru.tinkoff.decoro.watchers.FormatWatcher;
 
 /**
  * @author Mikhail Artemev
  */
 public interface FormattedTextChangeListener {
-    boolean beforeFormatting(String oldValue, String newValue);
-
-    void onTextFormatted(FormatWatcher formatter, String newFormattedText);
+    void onTextFormatted(@NonNull FormatWatcher formatter, @NonNull String newFormattedText);
 }

--- a/library/src/main/java/ru/tinkoff/decoro/Mask.java
+++ b/library/src/main/java/ru/tinkoff/decoro/Mask.java
@@ -63,6 +63,11 @@ public interface Mask extends Iterable<Slot>, Parcelable {
     boolean filled();
 
     /**
+     * Removes user input from this mask.
+     */
+    void clear();
+
+    /**
      * Method insert {@code input} to the buffer. Only validated characters would be inserted.
      * Hardcoded slots are omitted. Method returns new cursor position that is affected by input
      * and {@code cursorAfterTrailingHardcoded} flag. In most cases if input string is followed by
@@ -196,4 +201,12 @@ public interface Mask extends Iterable<Slot>, Parcelable {
      */
     void setForbidInputWhenFilled(boolean forbidInputWhenFilled);
 
+    /**
+     * Finds cursor position in unformatted string that corresponds to passed cursor position
+     * in a formatted string.
+     * @param cursorPosition
+     * @return corresponding cursor position in unformatted string
+     * @throws IndexOutOfBoundsException if cursorPosition < 0 or cursorPosition > size
+     */
+    int findCursorPositionInUnformattedString(int cursorPosition);
 }

--- a/library/src/main/java/ru/tinkoff/decoro/MaskImpl.java
+++ b/library/src/main/java/ru/tinkoff/decoro/MaskImpl.java
@@ -23,6 +23,7 @@ import android.support.annotation.Nullable;
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Iterator;
+import java.util.Locale;
 
 import ru.tinkoff.decoro.slots.Slot;
 
@@ -196,6 +197,7 @@ public class MaskImpl implements Mask {
         return true;
     }
 
+    @Override
     public void clear() {
         slots.clear();
         trimTail();
@@ -424,6 +426,31 @@ public class MaskImpl implements Mask {
     @Override
     public void setForbidInputWhenFilled(boolean forbidInputWhenFilled) {
         this.forbidInputWhenFilled = forbidInputWhenFilled;
+    }
+
+    @Override
+    public int findCursorPositionInUnformattedString(int cursorPosition) {
+        if (cursorPosition == 0) {
+            return 0;
+        } else if (cursorPosition < 0 || getSize() < cursorPosition) {
+            throw new IndexOutOfBoundsException(String.format(Locale.getDefault(), "Mask size: %d, passed index: %d", getSize(), cursorPosition));
+        }
+
+        Slot slot;
+        if (cursorPosition == getSize()) {
+            slot = slots.getLastSlot();
+        } else {
+            slot = slots.getSlot(cursorPosition);
+        }
+
+        do {
+            if (slot.hasTag(Slot.TAG_DECORATION)) {
+                cursorPosition--;
+            }
+            slot = slot.getPrevSlot();
+        } while (slot != null);
+
+        return cursorPosition;
     }
 
     public boolean isTerminated() {

--- a/library/src/main/java/ru/tinkoff/decoro/slots/PredefinedSlots.java
+++ b/library/src/main/java/ru/tinkoff/decoro/slots/PredefinedSlots.java
@@ -58,7 +58,7 @@ public final class PredefinedSlots {
             PredefinedSlots.digit(),
     };
 
-    public static final Slot[] CARD_NUMBER_STANDART = {
+    public static final Slot[] CARD_NUMBER_STANDARD = {
             PredefinedSlots.digit(),
             PredefinedSlots.digit(),
             PredefinedSlots.digit(),
@@ -96,7 +96,7 @@ public final class PredefinedSlots {
             PredefinedSlots.digit(),
     };
 
-    public static final Slot[] CARD_NUMBER_STANDART_MASKABLE = {
+    public static final Slot[] CARD_NUMBER_STANDARD_MASKABLE = {
             PredefinedSlots.digit(),
             maskableDigit(),
             maskableDigit(),

--- a/library/src/main/java/ru/tinkoff/decoro/watchers/FormatWatcher.java
+++ b/library/src/main/java/ru/tinkoff/decoro/watchers/FormatWatcher.java
@@ -53,7 +53,6 @@ public abstract class FormatWatcher implements TextWatcher, MaskFactory {
     private boolean initWithMask;
 
     private boolean selfEdit = false;
-    private boolean formattingCancelled = false;
 
     private FormattedTextChangeListener callback;
 
@@ -199,12 +198,6 @@ public abstract class FormatWatcher implements TextWatcher, MaskFactory {
             }
         }
 
-        // ask client code - should we proceed the modification of a mask
-        if (callback != null && callback.beforeFormatting(textBeforeChange.toString(), s.toString())) {
-            formattingCancelled = true;
-            return;
-        }
-
         if (diffMeasures.isRemovingChars()) {
             diffMeasures.setCursorPosition(mask.removeBackwards(diffMeasures.getRemoveEndPosition(), diffMeasures.getRemoveLength()));
         }
@@ -217,8 +210,7 @@ public abstract class FormatWatcher implements TextWatcher, MaskFactory {
     @Override
     public void afterTextChanged(Editable newText) {
 
-        if (formattingCancelled || selfEdit || mask == null) {
-            formattingCancelled = false;
+        if (selfEdit || mask == null) {
             return;
         }
 
@@ -237,11 +229,11 @@ public abstract class FormatWatcher implements TextWatcher, MaskFactory {
             setSelection(cursorPosition);
         }
 
+        textBeforeChange = null;
+
         if (callback != null) {
             callback.onTextFormatted(this, toString());
         }
-
-        textBeforeChange = null;
     }
 
     /**

--- a/library/src/main/java/ru/tinkoff/decoro/watchers/MaskFormatWatcher.java
+++ b/library/src/main/java/ru/tinkoff/decoro/watchers/MaskFormatWatcher.java
@@ -31,4 +31,11 @@ public class MaskFormatWatcher extends FormatWatcher {
         this.maskOriginal = maskOriginal;
         refreshMask();
     }
+
+    public void swapMask(MaskImpl newMask) {
+        maskOriginal = new MaskImpl(newMask);
+        maskOriginal.clear();
+
+        refreshMask(newMask.toString());
+    }
 }

--- a/library/src/main/java/ru/tinkoff/decoro/watchers/MaskFormatWatcher.java
+++ b/library/src/main/java/ru/tinkoff/decoro/watchers/MaskFormatWatcher.java
@@ -6,7 +6,7 @@ import ru.tinkoff.decoro.Mask;
 import ru.tinkoff.decoro.MaskImpl;
 
 /**
- * @author Mikhail Artemyev
+ * @author Mikhail Artemev
  */
 
 public class MaskFormatWatcher extends FormatWatcher {

--- a/library/src/main/java/ru/tinkoff/decoro/watchers/UnmodifiableMask.java
+++ b/library/src/main/java/ru/tinkoff/decoro/watchers/UnmodifiableMask.java
@@ -62,6 +62,13 @@ class UnmodifiableMask implements Mask {
     }
 
     @Override
+    public void clear() {
+        if (delegate != null) {
+            clear();
+        }
+    }
+
+    @Override
     public int insertAt(int position, CharSequence input, boolean cursorAfterTrailingHardcoded) {
         throw new UnsupportedOperationException();
     }
@@ -133,6 +140,11 @@ class UnmodifiableMask implements Mask {
         if (delegate != null) {
             delegate.setForbidInputWhenFilled(forbidInputWhenFilled);
         }
+    }
+
+    @Override
+    public int findCursorPositionInUnformattedString(int cursorPosition) {
+        return delegate == null ? cursorPosition : delegate.findCursorPositionInUnformattedString(cursorPosition);
     }
 
     @Override

--- a/library/src/test/java/ru/tinkoff/decoro/MaskImplTest.java
+++ b/library/src/test/java/ru/tinkoff/decoro/MaskImplTest.java
@@ -212,6 +212,33 @@ public class MaskImplTest {
 
     @Test
     public void clear() {
-
+        mask.insertFront("123");
+        assertEquals("1-23", mask.toString());
+        mask.clear();
+        assertEquals("", mask.toString());
+        mask.clear();
+        assertEquals("", mask.toString());
     }
+
+    @Test
+    public void findCursorPositionInUnformattedString_correct() throws Exception {
+        final Mask mask = MaskImpl.createTerminated(PredefinedSlots.RUS_PHONE_NUMBER);
+        assertEquals(1, mask.findCursorPositionInUnformattedString(1));
+        assertEquals(1, mask.findCursorPositionInUnformattedString(2));
+        assertEquals(1, mask.findCursorPositionInUnformattedString(3));
+        assertEquals(2, mask.findCursorPositionInUnformattedString(4));
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void findCursorPositionInUnformattedString_lower() throws Exception {
+        final Mask mask = MaskImpl.createTerminated(PredefinedSlots.RUS_PHONE_NUMBER);
+        mask.findCursorPositionInUnformattedString(-1);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void findCursorPositionInUnformattedString_upper() throws Exception {
+        final Mask mask = MaskImpl.createTerminated(PredefinedSlots.RUS_PHONE_NUMBER);
+        assertEquals(mask.getSize(), mask.findCursorPositionInUnformattedString(100500));
+    }
+
 }

--- a/library/src/test/java/ru/tinkoff/decoro/MaskImplTest.java
+++ b/library/src/test/java/ru/tinkoff/decoro/MaskImplTest.java
@@ -33,7 +33,7 @@ import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
 
 /**
- * @author Mikhail Artemyev
+ * @author Mikhail Artemev
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)


### PR DESCRIPTION
What's new:
1) MaskFormatWatcher now able to swap it's mask. This is useful inside FormattedTextChangeListener#onTextFormatted
2) FormattedTextChangeListener#beforeFormatting method removed
3) Spelling fixes by (Thanks to @RustamG)