### PR TITLE
Fix crash during state restoring

### DIFF
--- a/library/src/main/java/ru/tinkoff/decoro/SlotsList.java
+++ b/library/src/main/java/ru/tinkoff/decoro/SlotsList.java
@@ -318,7 +318,7 @@ class SlotsList implements Iterable<Slot>, Parcelable {
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeInt(this.size);
         if (size > 0) {
-            dest.writeArray(toArray());
+            dest.writeTypedArray(toArray(), flags);
         }
     }
 
@@ -326,7 +326,7 @@ class SlotsList implements Iterable<Slot>, Parcelable {
         this.size = in.readInt();
         if (size > 0) {
             Slot[] slots = new Slot[this.size];
-            in.readArray(Slot.class.getClassLoader());
+            in.readTypedArray(slots, Slot.CREATOR);
             linkSlots(slots, this);
         }
     }


### PR DESCRIPTION
Fix crash which occurred during restoring of Mask.java.

```java
FATAL EXCEPTION: main
Process: ru.tinkoff.formattingdemo, PID: 19078
java.lang.RuntimeException: Unable to start activity ComponentInfo{ru.tinkoff.formattingdemo/ru.tinkoff.decoro.demo.MainActivity}: java.lang.NullPointerException: Attempt to read from field 'int ru.tinkoff.decoro.slots.Slot.rulesFlags' on a null object reference
    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2665)
    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2726)
    at android.app.ActivityThread.-wrap12(ActivityThread.java)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1477)
    at android.os.Handler.dispatchMessage(Handler.java:102)
    at android.os.Looper.loop(Looper.java:154)
    at android.app.ActivityThread.main(ActivityThread.java:6119)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:886)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:776)
 Caused by: java.lang.NullPointerException: Attempt to read from field 'int ru.tinkoff.decoro.slots.Slot.rulesFlags' on a null object reference
    at ru.tinkoff.decoro.slots.Slot.<init>(Slot.java:100)
    at ru.tinkoff.decoro.SlotsList.linkSlots(SlotsList.java:53)
    at ru.tinkoff.decoro.SlotsList.<init>(SlotsList.java:330)
    at ru.tinkoff.decoro.SlotsList$1.createFromParcel(SlotsList.java:337)
    at ru.tinkoff.decoro.SlotsList$1.createFromParcel(SlotsList.java:334)
    at android.os.Parcel.readParcelable(Parcel.java:2471)
    at ru.tinkoff.decoro.MaskImpl.<init>(MaskImpl.java:585)
    at ru.tinkoff.decoro.MaskImpl$1.createFromParcel(MaskImpl.java:591)
    at ru.tinkoff.decoro.MaskImpl$1.createFromParcel(MaskImpl.java:588)
    at android.os.Parcel.readParcelable(Parcel.java:2471)
    at android.os.Parcel.readValue(Parcel.java:2365)
    at android.os.Parcel.readArrayMapInternal(Parcel.java:2732)
    at android.os.BaseBundle.unparcel(BaseBundle.java:269)
    at android.os.BaseBundle.getBoolean(BaseBundle.java:731)
    at android.app.Activity.restoreHasCurrentPermissionRequest(Activity.java:6920)
    at android.app.Activity.performCreate(Activity.java:6678)
    at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1118)
    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2618)
    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2726) 
    at android.app.ActivityThread.-wrap12(ActivityThread.java) 
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1477) 
    at android.os.Handler.dispatchMessage(Handler.java:102) 
    at android.os.Looper.loop(Looper.java:154) 
    at android.app.ActivityThread.main(ActivityThread.java:6119) 
    at java.lang.reflect.Method.invoke(Native Method) 
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:886) 
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:776)  ```