### PR TITLE
Fix LetterValidator bug

### DIFF
--- a/library/src/main/java/ru/tinkoff/decoro/slots/SlotValidators.java
+++ b/library/src/main/java/ru/tinkoff/decoro/slots/SlotValidators.java
@@ -145,18 +145,19 @@ public final class SlotValidators {
         }
 
         private boolean validateEnglishLetter(final char value) {
-            return supportsEnglish == isEnglishCharacter(value); // true when both 0 or 1
+            return supportsEnglish && isEnglishCharacter(value); // true when both 1
         }
 
         private boolean validateRussianLetter(final char value) {
-            final int code = (int) value;
-            boolean russian = 'А' <= code && code <= 'я'; // 'А' is russian!!
-
-            return supportsRussian == russian; // true when both 0 or 1
+            return supportsRussian && isRussianCharacter(value); // true when both 1
         }
 
         private boolean isEnglishCharacter(final int charCode) {
             return ('A' <= charCode && charCode <= 'Z') || ('a' <= charCode && charCode <= 'z');
+        }
+
+        private boolean isRussianCharacter(final int charCode) {
+            return 'А' <= charCode && charCode <= 'я'; // 'А' is russian!!
         }
 
         @Override


### PR DESCRIPTION
When using LetterValidator with different arguments, it is possible to type other characters than letters.

##### Example
```Java
Slot.SlotValidator letterValidator = new LetterValidator(true, false);
letterValidator.validate('&'); // return true
```

When using this constructor you cannot type Russian letters, but can type any other character. To avoid this bug, you need to correct the validation condition.

