### PR TITLE
Update MaskImpl.java

### DIFF
--- a/library/src/main/java/ru/tinkoff/decoro/MaskImpl.java
+++ b/library/src/main/java/ru/tinkoff/decoro/MaskImpl.java
@@ -248,7 +248,7 @@ public class MaskImpl implements Mask {
             // if there were any non-hardcoded slots skipped while looking for next slot offset
             // and we don't allow 'spots' in the input - we should stop inserting right now
             if (!showingEmptySlots && slotForInputIndex.nonHarcodedSlotSkipped) {
-                break;
+                continue;
             }
 
             cursorPosition += slotForInputIndex.indexOffset;


### PR DESCRIPTION
Как написано в комментариях перед этой строкой

> // if there were any non-hardcoded slots skipped while looking for next slot offset
> // and we don't allow 'spots' in the input - we should stop inserting right now

Проблема в том, что по факту мы не пропускам символы, а просто заканчивам вставку. Это критично

Пример c edittext с установленным ограничением в inputType "phone": 
```
val passportMask: MaskImpl = MaskImpl.createTerminated(UnderscoreDigitSlotsParser().parseSlots("____ ______"))
MaskFormatWatcher(passportMask).installOn(passportInput.editText)
```

Все работает хорошо, до тех пор, пока мы не попытаемся вставить текст из буфера. 

Например текст в буфере "паспорт 2222 серия 555555"
При вставке, в цикл приходит строка отфильтрованная согласно input фильтр т.е " 2222 555555"
Проблема начинается если эта строка содержит захардкоженных символ (Неважно где, вставка прекращается с того места, где есть захардкоженный символ). И начиная с этого символа, мы выходим из цикла игнорируя все остальное. Т.е в данном случае в поле просто ничего не вставится т.к начинается с пробела. Но это неверно, мы хотим получить "2222 555555" в поле ввода. Для этого вместо break мы делаем continue, пропуская все захардкоженные символы и вставляя только значащие.

Потестил, работает